### PR TITLE
Add branding options to webpack config.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,13 +1,13 @@
 <html>
-    
+
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title><%= htmlWebpackPlugin.options.title %></title>
-        <meta property="og:title" content="Reactiflux Dashboard">
+        <meta property="og:title" content="<%= htmlWebpackPlugin.options.title %>">
         <meta property="og:type" content="website">
-        <meta property="og:url" content="http://pipend.github.io/reactiflux-dashboard/">
-        <meta property="og:image" content="https://avatars0.githubusercontent.com/u/12956758?v=3&amp;s=400">
+        <meta property="og:url" content="<%= htmlWebpackPlugin.options.url %>">
+        <meta property="og:image" content="<%= htmlWebpackPlugin.options.image %>">
         <meta property="og:description" content="Created using pipe &amp; pipe-storyboard using data collected by baymax, a discord bot">
     </head>
 

--- a/webpack.config.ls
+++ b/webpack.config.ls
@@ -1,8 +1,8 @@
 require! \path
 HtmlWebpackPlugin = require \html-webpack-plugin
 
-module.exports = 
-    entry: 
+module.exports =
+    entry:
         * \./public/index.ls
         ...
     output:
@@ -19,6 +19,8 @@ module.exports =
     plugins:
         * new HtmlWebpackPlugin do
             title: 'Reactiflux on Discord'
+            url: 'http://pipend.github.io/reactiflux-dashboard/'
+            image: 'https://avatars0.githubusercontent.com/u/12956758?v=3&amp;s=400'
             template: \public/index.html
         ...
 


### PR DESCRIPTION
This fully converts the template index.html file to use config options from webpack.config.js, so that meta tags may be customized out-of-repo.

Let me know if any changes are requested, I can make adjustments as necessary.
